### PR TITLE
Fix when variation is removed for the line item.

### DIFF
--- a/src/Geta.EPi.Commerce.Extensions/LineItemExtensions.cs
+++ b/src/Geta.EPi.Commerce.Extensions/LineItemExtensions.cs
@@ -4,6 +4,7 @@ using EPiServer;
 using EPiServer.Commerce.Catalog;
 using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Commerce.Order;
+using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using Mediachase.Commerce;
 using Mediachase.Commerce.Catalog;
@@ -21,14 +22,19 @@ namespace Geta.EPi.Commerce.Extensions
 
         public static string GetUrl(this ILineItem lineItem)
         {
-            var variantLink = _referenceConverter.Service.GetContentLink(lineItem.Code);
-            var variant = _contentLoader.Service.Get<VariationContent>(variantLink);
-            return variant.GetUrl();
+            var link = _referenceConverter.Service.GetContentLink(lineItem.Code);
+            if (link == null || link == ContentReference.EmptyReference)
+            {
+                return string.Empty;
+            }
+            var variant = _contentLoader.Service.Get<VariationContent>(link);
+            return variant?.GetUrl() ?? string.Empty;
         }
 
         public static string GetFullUrl(this ILineItem lineItem)
         {
             var rightUrl = lineItem.GetUrl();
+            if (string.IsNullOrEmpty(rightUrl)) return string.Empty;
             var baseUrl = HttpContext.Current.Request.Url.GetLeftPart(UriPartial.Authority);
             return new Uri(new Uri(baseUrl), rightUrl).ToString();
         }
@@ -40,8 +46,13 @@ namespace Geta.EPi.Commerce.Extensions
 
         private static string GetThumbnailUrl(string code)
         {
-            var content = _contentLoader.Service.Get<VariationContent>(_referenceConverter.Service.GetContentLink(code, CatalogContentType.CatalogEntry));
-
+            var link = _referenceConverter.Service.GetContentLink(code, CatalogContentType.CatalogEntry); 
+            if (link == null || link == ContentReference.EmptyReference)
+            {
+                return string.Empty;
+            }
+            var content = _contentLoader.Service.Get<VariationContent>(link);
+            if (content == null) return string.Empty;
             return _thumbnailUrlResolver.Service.GetThumbnailUrl(content, "thumbnail");
         }
 


### PR DESCRIPTION
Sometimes when viewing old orders, variations already have been deleted.
So there is no guarantee that you can get a url for that item or an
image url for that item.